### PR TITLE
feat: reducing required swift version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -8,7 +8,10 @@ let package = Package(
     platforms: [
         // specify each minimum deployment requirement,
         //otherwise the platform default minimum is used.
-       .macOS(.v11),
+       .macOS(.v10_15),
+       .iOS(.v13),
+       .tvOS(.v13),
+       .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
I have a dead-simple linear bucket histogram I'm using in an existing app, and I'd very much like to replace it with this HdrHistogram implementation - but I still need to back-support to Catalina for that app. I checked this package locally, and lowering the versions doesn't impact anything **currently** - but I realize there's more development that you have in mind here. So... I'm opening this PR to downgrade the required versions of Swift, and related OS pieces, for your consideration.

## Description

- reduces swift required to build this package to Swift 5.6
- reduces macOS support back to allow/support Catalina (10.15)
- adds explicit iOS and watchOS support

## How Has This Been Tested?

`swift build` && `swift test`

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
